### PR TITLE
Store template names in module attribute

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -164,6 +164,8 @@ defmodule Phoenix.Template do
     codes = Enum.map(pairs, &elem(&1, 1))
 
     quote do
+      @phoenix_templates unquote(names)
+      
       unquote(codes)
 
       # Catch-all clause for template rendering.
@@ -183,7 +185,7 @@ defmodule Phoenix.Template do
       Returns the template root alongside all templates.
       """
       def __templates__ do
-        {@phoenix_root, @phoenix_pattern, unquote(names)}
+        {@phoenix_root, @phoenix_pattern, @phoenix_templates}
       end
 
       @doc """


### PR DESCRIPTION
I'm working on an extension of phoenix views to allow for automatically generated component libraries and I need the compiled templates at compile time to further work with them like storing their content for display or differenciating other files in the folder from templates.